### PR TITLE
Fix (current-module-name-resolver) warnings.

### DIFF
--- a/drscheme/tool.ss
+++ b/drscheme/tool.ss
@@ -230,11 +230,11 @@
           (dynamic-require standard-library #f)
           (dynamic-require debug #f)
           (dynamic-require lang #f)
-          (let ([path1 ((current-module-name-resolver) module-forms #f #f)]
-                [path2 ((current-module-name-resolver) runtime #f #f)]
-                [path3 ((current-module-name-resolver) standard-library #f #f)]
-                [path4 ((current-module-name-resolver) debug #f #f)]
-                [path5 ((current-module-name-resolver) lang #f #f)]
+          (let ([path1 ((current-module-name-resolver) module-forms #f #f #t)]
+                [path2 ((current-module-name-resolver) runtime #f #f #t)]
+                [path3 ((current-module-name-resolver) standard-library #f #f #t)]
+                [path4 ((current-module-name-resolver) debug #f #f #t)]
+                [path5 ((current-module-name-resolver) lang #f #f #t)]
                 [n (current-namespace)])
             (run-in-user-thread
              (lambda ()

--- a/private/runtime/namespace.ss
+++ b/private/runtime/namespace.ss
@@ -32,10 +32,10 @@
       (dynamic-require standard-library #f)
       (dynamic-require debug #f)
       (namespace-require 'javascript/lang/lang)
-      (let ([path1 ((current-module-name-resolver) runtime #f #f)]
-            [path2 ((current-module-name-resolver) standard-library #f #f)]
-            [path3 ((current-module-name-resolver) debug #f #f)]
-            [path4 ((current-module-name-resolver) lang #f #f)])
+      (let ([path1 ((current-module-name-resolver) runtime #f #f #t)]
+            [path2 ((current-module-name-resolver) standard-library #f #f #t)]
+            [path3 ((current-module-name-resolver) debug #f #f #t)]
+            [path4 ((current-module-name-resolver) lang #f #f #t)])
         (namespace-attach-module ns path1)
         (namespace-attach-module ns path2)
         (namespace-attach-module ns path3)


### PR DESCRIPTION
`((current-module-name-resolver) x #f #f)` prints the following
deprecation warning:

    default module name resolver called with three arguments

Update the code base to use the four argument version.  Pass `#t`
as the fourth argument to indicate the module should be loaded.

`raco test .` passes for me locally.